### PR TITLE
Handling of the missing config file fixed

### DIFF
--- a/pysmartmeter/cli.py
+++ b/pysmartmeter/cli.py
@@ -88,7 +88,7 @@ def store_settings():
     log_config()
 
     try:
-        settings: MqttSettings = get_mqtt_settings()
+        settings: MqttSettings = get_mqtt_settings(False)
     except FileNotFoundError:
         print('No settings stored, yet. ok.')
         print()

--- a/pysmartmeter/utilities/credentials.py
+++ b/pysmartmeter/utilities/credentials.py
@@ -18,12 +18,15 @@ def store_mqtt_settings(settings: MqttSettings):
     return CREDENTIAL_FILE_PATH
 
 
-def get_mqtt_settings() -> MqttSettings:
+def get_mqtt_settings(exit_on_missing_config = True) -> MqttSettings:
     try:
         data_str = CREDENTIAL_FILE_PATH.read_text(encoding='UTF-8')
     except FileNotFoundError as err:
         print(f'ERROR: File not found: {err}')
         print('(Hint save settings first with: "./cli.sh store-settings")')
-        sys.exit(1)
+        if (exit_on_missing_config):
+       	    sys.exit(1)
+        else:
+            raise FileNotFoundError ("Config not found.")
     settings = MqttSettings.from_json(data_str)
     return settings


### PR DESCRIPTION
If the config file is missing, the program is always terminated with sys.exit(1). But this should not happen when calling "store-settings".